### PR TITLE
PLAT-277  update to support python 3.11 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 build/
 .idea/
 .coverage
+check_pr_ready.sh

--- a/pyitlib/pyitlib_version.py
+++ b/pyitlib/pyitlib_version.py
@@ -1,4 +1,4 @@
 """pyitlib version"""
 
-__version__ = u'0.2.6'
+__version__ = u'0.2.7'
 # __version_short__ = u'0.2'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 future>=0.16.0
 numpy>=1.22.4,<=1.23.5
 pandas<2
-scikit-learn==1.0.2
+scikit-learn==1.1.3
 scipy==1.10.1
 
 # test

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'pandas<2',
         'numpy>=1.22.4,<=1.23.5',
-        'scikit-learn==1.0.2',
+        'scikit-learn==1.1.3',
         'scipy==1.10.1',
         'future>=0.16.0'
     ],


### PR DESCRIPTION
to support python 3.11 build, bump  `scikit-learn==1.1.3`

Python 3.11 test
<img width="1512" alt="Screenshot 2024-06-13 at 10 35 06 AM" src="https://github.com/replica-analytics/pyitlib/assets/9092528/9365b0ed-2962-4ebd-85de-a3e919bb283f">

Python 3.8 test
<img width="1511" alt="Screenshot 2024-06-13 at 10 41 16 AM" src="https://github.com/replica-analytics/pyitlib/assets/9092528/9ea031c7-6c67-4936-8935-38f9908dd016">
