### PR TITLE
RAS-6085 update packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 .idea/
 .coverage
 check_pr_ready.sh
+.DS_Store

--- a/pyitlib/pyitlib_version.py
+++ b/pyitlib/pyitlib_version.py
@@ -1,4 +1,4 @@
 """pyitlib version"""
 
-__version__ = u'0.2.9'
+__version__ = u'0.2.10'
 # __version_short__ = u'0.2'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,14 +2,14 @@ future>=1.0.0
 numpy>=2.0.0
 pandas>=2.2.0
 scikit-learn==1.5.2
-scipy==1.14.1
+scipy==1.15.2
 
 # test
-pytest==8.3.3
+pytest==8.3.5
 coverage==7.6.1
 
 # security dependency check
-safety==3.2.8
+pip-audit==2.9.0
 
 # support build
 hatch==0.23.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pandas>=2.2.0',
         'numpy>=2.0.0',
         'scikit-learn==1.5.2',
-        'scipy==1.14.1',
+        'scipy==1.15.2',
         'future>=1.0.0'
     ],
     keywords=['entropy', 'information theory', 'Shannon information',


### PR DESCRIPTION
update to use `scipy==1.15.2` and start use `pip-audit==2.9.0`

Support Python 3.11
<img width="1449" alt="Screenshot 2025-05-16 at 10 12 25 PM" src="https://github.com/user-attachments/assets/b34fef7a-619f-43c2-b263-24d468a9938f" />

Support Python 3.12
<img width="1443" alt="Screenshot 2025-05-16 at 10 16 38 PM" src="https://github.com/user-attachments/assets/006763f9-acda-4228-95bd-1228521af67a" />
